### PR TITLE
Bugfixes in the AirTagGeneration scripts

### DIFF
--- a/AirTagGeneration/.gitignore
+++ b/AirTagGeneration/.gitignore
@@ -1,0 +1,4 @@
+data.json
+LocationMap_*.html
+venv/
+keys/*

--- a/AirTagGeneration/cores/pypush_gsa_icloud.py
+++ b/AirTagGeneration/cores/pypush_gsa_icloud.py
@@ -75,12 +75,12 @@ def gsa_authenticate(username, password, second_factor='sms'):
     if "sp" not in r:
         print("Authentication Failed. Check your Apple ID and password.")
         raise Exception("AuthenticationError")
-    if r["sp"] != "s2k":
-        print(f"This implementation only supports s2k. Server returned {r['sp']}")
+    if r["sp"] != "s2k" and r["sp"] != "s2k_fo":
+        print(f"This implementation only supports s2k and s2k_fo. Server returned {r['sp']}")
         return
 
     # Change the password out from under the SRP library, as we couldn't calculate it without the salt.
-    usr.p = encrypt_password(password, r["s"], r["i"])
+    usr.p = encrypt_password(password, r["s"], r["i"], r["sp"] == "s2k_fo")
 
     M = usr.process_challenge(r["s"], r["B"])
 
@@ -207,8 +207,9 @@ def generate_meta_headers(serial="0", user_id=uuid.uuid4(), device_id=uuid.uuid4
     }
 
 
-def encrypt_password(password, salt, iterations):
-    p = hashlib.sha256(password.encode("utf-8")).digest()
+def encrypt_password(password, salt, iterations, hex=False):
+    hash = hashlib.sha256(password.encode("utf-8"))
+    p = hash.hexdigest() if hex else hash.digest()
     return pbkdf2.PBKDF2(p, salt, iterations, SHA256).read(32)
 
 

--- a/AirTagGeneration/request_reports.py
+++ b/AirTagGeneration/request_reports.py
@@ -31,8 +31,8 @@ def decrypt(enc_data, algorithm_dkey, mode):
 def decode_tag(data):
     latitude = struct.unpack(">i", data[0:4])[0] / 10000000.0
     longitude = struct.unpack(">i", data[4:8])[0] / 10000000.0
-    confidence = int.from_bytes(data[8:9])
-    status = int.from_bytes(data[9:10])
+    confidence = int.from_bytes(data[8:9], 'big')
+    status = int.from_bytes(data[9:10], 'big')
     return {'lat': latitude, 'lon': longitude, 'conf': confidence, 'status': status}
 
 


### PR DESCRIPTION
- Fix for `This implementation only supports s2k. Server returned s2k_fo`
- Fix for `from_bytes() missing required argument 'byteorder' (pos 2)`
- Added .gitignore