### PR TITLE
Fix requirements.txt error "no module named: setuptools"

### DIFF
--- a/AirTagGeneration/requirements.txt
+++ b/AirTagGeneration/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 requests~=2.31.0
 urllib3~=2.1.0
 cryptography~=41.0.7
@@ -11,4 +12,3 @@ certifi
 paho-mqtt
 pycryptodome
 python-multipart
-setuptools

--- a/AirTagGeneration/requirements.txt
+++ b/AirTagGeneration/requirements.txt
@@ -11,3 +11,4 @@ certifi
 paho-mqtt
 pycryptodome
 python-multipart
+setuptools


### PR DESCRIPTION
![Code_-_Insiders_20240819_p45cdEvHsr](https://github.com/user-attachments/assets/e839d1d4-3e20-4676-94b4-9c079eff13a1)

When following the instructions on how to generate your own airtag, step 6 `pip3 install -r requirements.txt` is broken, which says "No module named: setuptools".

Adding this package to requirements.txt will fix this problem in the future.
