### PR TITLE
Remove tracker from YoutTube URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This app extends the functionality of the FlipperZero's bluetooth capabilities, 
 <summary><b>Option B: AirTag Key Generation</b></summary>
   <br>
 
-Video Tutorial: https://youtu.be/XGwHmwvQoqo?si=CAsKWEqGP5VFi9p9
+Video Tutorial: https://www.youtube.com/watch?v=XGwHmwvQoqo
 
 ### Prerequisites
 


### PR DESCRIPTION
The `si` parameter is a share id used to track users, remove it from the README.